### PR TITLE
gha: Enable publishing to PyPi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,5 @@ jobs:
       - name: Build package
         run: python -m build
 
-# Uncomment this once we have a PyPi repo
-#      - name: Publish distribution to PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ doesn't yet support SPDX 3)
 
 ## Installation (PyPi)
 
-**TODO** Add instructions for how to install these from PyPi once they are published there
+```shell
+python3 -m pip install spdx-python-model
+```
 
 ## Installation (Git)
 
@@ -69,8 +71,6 @@ pytest -vx
 ```
 
 ## Making a new release
-
-**NOTE** We do not have a PyPi repo yet, so this won't work
 
 To make a new release of this repository, bump the version number found in
 `src/spdx_python_model/version.py`, and merge it into the repo. After this,


### PR DESCRIPTION
There are projects wanting to use the Python bindings, and pulling them from github is annoying, particularly because it's not allowed to publish a downstream package that contains these bindings if they are pulled from GitHub.

As such, enable publishing to PyPi