### PR TITLE
Update to latest shacl2code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "shacl2code == 0.0.20",
     "pytest >= 7.4",
 ]
 
@@ -35,7 +34,7 @@ Issues = "https://github.com/spdx/spdx-python-model/issues"
 requires = [
     "hatchling",
     "hatch-build-scripts",
-    "shacl2code == 0.0.20",
+    "shacl2code == 0.0.21",
 ]
 build-backend = "hatchling.build"
 

--- a/src/spdx_python_model/version.py
+++ b/src/spdx_python_model/version.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-VERSION = "0.0.1"
+VERSION = "0.0.2"


### PR DESCRIPTION
Updates to the latest version of shacl2code. This changes the way some objects are initialized in the Python bindings, see: https://github.com/JPEWdev/shacl2code/releases/tag/v0.0.21