### PR TITLE
Use SPDX license key in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
+license = "Apache-2.0"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
- Using license classifiers is deprecated https://peps.python.org/pep-0639/#deprecate-license-classifiers
- Use license key (a valid SPDX license expression) in the [project] instead https://peps.python.org/pep-0639/#add-string-value-to-license-key