### PR TITLE
Add py.typed type hint marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
 ]
 license = "Apache-2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Typing :: Typed",
 ]
 license = "Apache-2.0"
 

--- a/src/spdx_python_model/py.typed
+++ b/src/spdx_python_model/py.typed
@@ -1,0 +1,1 @@
+# PEP 561: Type hints marker


### PR DESCRIPTION
To indicates that this package supports typing.

This will silent linter warning of "import-untyped" when importing spdx_python_model.

More about py.typed marker
https://peps.python.org/pep-0561/