### PR TITLE
Copy stubs to bindings path after generation at build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 
 src/spdx_python_model/bindings/
 gen/*.py
+gen/*.pyi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,6 @@ commands = [
     "./generate-bindings"
 ]
 artifacts = [
-    "*.py"
+    "*.py",
+    "*.pyi",
 ]


### PR DESCRIPTION
- Add *.pyi to artifacts list in build script settings,
  to instruct the build script to copy type stubs (if any) to output path.
- Add `py.typed` PEP 561 marker file

The marker file is to indicate type support.
While the actual type information are in the stubs.

This will assist static type checkers and code completion.

