### PR TITLE
Update build dependencies; shacl2code == 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ Issues = "https://github.com/spdx/spdx-python-model/issues"
 
 [build-system]
 requires = [
-    "hatchling",
-    "hatch-build-scripts",
-    "shacl2code == 0.0.25",
+    "hatchling >= 1.27.0",
+    "hatch-build-scripts >= 0.0.4",
+    "shacl2code == 1.0.0",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Closed. Use #24

- hatchling >= 1.27.0 -- most recent version that supports Python 3.9
- hatch-build-scripts >= 0.0.4 -- most recent version that supports Python 3.9
- [shacl2code == 1.0.0](https://github.com/JPEWdev/shacl2code/releases/tag/v1.0.0)
