### PR TITLE
Update shacl2code to 1.0.0

### DIFF
--- a/gen/generate-bindings
+++ b/gen/generate-bindings
@@ -21,14 +21,14 @@ for v in $SPDX_VERSIONS; do
             --context-url "file://${SHACL2CODE_SPDX_DIR}/$v/spdx-context.jsonld" https://spdx.org/rdf/$v/spdx-context.jsonld  \
             --license Apache-2.0 \
             python \
-            -o "$MODNAME.py"
+            --output "$MODNAME"
     else
         shacl2code generate --input https://spdx.org/rdf/$v/spdx-model.ttl \
             --input https://spdx.org/rdf/$v/spdx-json-serialize-annotations.ttl \
             --context https://spdx.org/rdf/$v/spdx-context.jsonld \
             --license Apache-2.0 \
             python \
-            -o "$MODNAME.py"
+            --output "$MODNAME"
     fi
 
     echo "from . import $MODNAME" >> __init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ Issues = "https://github.com/spdx/spdx-python-model/issues"
 
 [build-system]
 requires = [
-    "hatchling",
-    "hatch-build-scripts",
-    "shacl2code == 0.0.25",
+    "hatchling >= 1.27.0",
+    "hatch-build-scripts >= 0.0.4",
+    "shacl2code == 1.0.0",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
- Update dependencies
  - hatchling >= 1.27.0 -- most recent version that supports Python 3.9
  - hatch-build-scripts >= 0.0.4 -- most recent version that supports Python 3.9
  - [shacl2code == 1.0.0](https://github.com/JPEWdev/shacl2code/releases/tag/v1.0.0)
- Update gen/generate-bindings to output to directory name

To resolve #22 