### PR TITLE
Add a link to tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spdx-python-model
 
-Generated Python code for SPDX Spec version 3
+Generated Python code for SPDX specification version 3.
 
 All bindings in this repository are generated using
 [shacl2code](https://github.com/JPEWdev/shacl2code) at the time the package is
@@ -10,10 +10,10 @@ built.
 manipulating SPDX files. While they are fully functions, they lack higher level
 helper functions that may be useful for creating SPDX documents. If you want a
 higher level approach, please see the
-[SPDX Python Tools](https://github.com/spdx/tools-python) (however this repo
+[SPDX Python Tools](https://github.com/spdx/tools-python) (however that project
 doesn't yet support SPDX 3)
 
-## Installation (PyPi)
+## Installation (PyPI)
 
 ```shell
 python3 -m pip install spdx-python-model
@@ -22,7 +22,7 @@ python3 -m pip install spdx-python-model
 ## Installation (Git)
 
 If you would like to pull the bindings directly from Git instead of using a
-released version from PyPi, the following command can be used:
+released version from PyPI, the following command can be used:
 
 ```shell
 python3 -m pip install git+https://github.com/spdx/spdx-python-model.git@main
@@ -52,6 +52,11 @@ from spdx_python_model import v3_0_1 as spdx_3_0
 p = spdx_3_0.Person()
 ```
 
+Check out this short [Python notebook tutorial][tutorial]
+to get started with spdx-python-model.
+
+[tutorial]: https://gist.github.com/bact/7227ad858500c2097a25344a4af015d6
+
 ## Testing
 
 This repository has support for running tests against the bindings using `pytest`.
@@ -78,4 +83,4 @@ make a new release in GitHub with the name `v` + *VERSION*, where *VERSION*
 matches the version number specified in `version.py` (e.g. `v1.0.0`).
 
 After this, GitHub actions will do the rest to build the package and publish it
-to PyPi
+to PyPI.


### PR DESCRIPTION
Added a link to this Python notebook tutorial https://gist.github.com/bact/7227ad858500c2097a25344a4af015d6 to the README.md

Also fix PyPI casing.