### PR TITLE
Add notes on SHACL2CODE_SPDX_DIR env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ higher level approach, please see the
 [SPDX Python Tools](https://github.com/spdx/tools-python) (however this repo
 doesn't yet support SPDX 3)
 
-## Installation (PyPi)
+## Installation
+
+### Install from PyPI
 
 ```shell
 python3 -m pip install spdx-python-model
 ```
 
-## Installation (Git)
+### Install from Git
 
 If you would like to pull the bindings directly from Git instead of using a
-released version from PyPi, the following command can be used:
+released version from PyPI, the following command can be used:
 
 ```shell
 python3 -m pip install git+https://github.com/spdx/spdx-python-model.git@main
@@ -30,6 +32,23 @@ python3 -m pip install git+https://github.com/spdx/spdx-python-model.git@main
 
 Note that this will pull the latest version from the `main` branch. If you want
 a specific commit, replace `main` with the git commit SHA
+
+### Install using local SPDX model files
+
+Set the `SHACL2CODE_SPDX_DIR` environment variable to a local directory to
+bypass network downloads during builds.
+The directory must follow this structure:
+
+```text
+<SHACL2CODE_SPDX_DIR>/
+└── v[VERSION]/
+    ├── spdx-context.jsonld
+    ├── spdx-json-serialize-annotations.ttl
+    └── spdx-model.ttl
+```
+
+Useful for pre-release versions lacking official URLs and
+for testing new SPDX models.
 
 ## Usage
 
@@ -78,4 +97,4 @@ make a new release in GitHub with the name `v` + *VERSION*, where *VERSION*
 matches the version number specified in `version.py` (e.g. `v1.0.0`).
 
 After this, GitHub actions will do the rest to build the package and publish it
-to PyPi
+to PyPI.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,15 @@ python3 -m pip install git+https://github.com/spdx/spdx-python-model.git@main
 Note that this will pull the latest version from the `main` branch. If you want
 a specific commit, replace `main` with the git commit SHA
 
-### Install using local SPDX model files
+### Install/build using local SPDX model files
 
-To build using local SPDX model files instead of downloading them from
-<https://spdx.org>:
+Using local SPDX model files is ideal for testing pre-release versions
+or when official URLs are not yet live.
+
+It is also required for build systems that prohibit network access during
+packaging, such as Debian or Yocto.
+
+To build using local model files:
 
 1) Clone the repository:
 
@@ -45,33 +50,51 @@ To build using local SPDX model files instead of downloading them from
     cd spdx-python-model
     ```
 
-2) Set the model directory:
+2) Download model files:
 
-   Point `SHACL2CODE_SPDX_DIR` to your local files to bypass network downloads
-   during builds.
+    Run the following commands to download the necessary files
+    for a specific SPDX version and keep it in a local directory:
 
-   ```shell
-   export SHACL2CODE_SPDX_DIR=/path/to/models
-   ```
+    ```shell
+    mkdir -p ~/spdx_models/v3.0.1
+    cd ~/spdx_models/v3.0.1
+    wget https://spdx.org/rdf/3.0.1/spdx-context.jsonld
+    wget https://spdx.org/rdf/3.0.1/spdx-json-serialize-annotations.ttl
+    wget https://spdx.org/rdf/3.0.1/spdx-model.ttl
+    ```
 
-3) Install:
+    Or use your own model files.
+
+    The local directory must be organized by SPDX version,
+    with specific file names.
+
+    ```text
+    <SHACL2CODE_SPDX_DIR>/
+    └── v[VERSION]/
+        ├── spdx-context.jsonld
+        ├── spdx-json-serialize-annotations.ttl
+        └── spdx-model.ttl
+    ```
+
+3) Set the model directory:
+
+    Point `SHACL2CODE_SPDX_DIR` environment variable to that local directory.
+
+    ```shell
+    export SHACL2CODE_SPDX_DIR=~/spdx_models
+    ```
+
+4) Install/build:
 
     ```shell
     python3 -m pip install .
     ```
 
-The local directory must be organized by SPDX version:
+    or
 
-```text
-/path/to/models/
-└── v[VERSION]/
-    ├── spdx-context.jsonld
-    ├── spdx-json-serialize-annotations.ttl
-    └── spdx-model.ttl
-```
-
-This is ideal for testing new models or pre-release versions where official
-URLs are not yet live.
+    ```shell
+    python3 -m build
+    ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -35,20 +35,43 @@ a specific commit, replace `main` with the git commit SHA
 
 ### Install using local SPDX model files
 
-Set the `SHACL2CODE_SPDX_DIR` environment variable to a local directory to
-bypass network downloads during builds.
-The directory must follow this structure:
+To build using local SPDX model files instead of downloading them from
+<https://spdx.org>:
+
+1) Clone the repository:
+
+    ```shell
+    git clone https://github.com/spdx/spdx-python-model.git
+    cd spdx-python-model
+    ```
+
+2) Set the model directory:
+
+   Point `SHACL2CODE_SPDX_DIR` to your local files to bypass network downloads
+   during builds.
+
+   ```shell
+   export SHACL2CODE_SPDX_DIR=/path/to/models
+   ```
+
+3) Install:
+
+    ```shell
+    python3 -m pip install .
+    ```
+
+The local directory must be organized by SPDX version:
 
 ```text
-<SHACL2CODE_SPDX_DIR>/
+/path/to/models/
 └── v[VERSION]/
     ├── spdx-context.jsonld
     ├── spdx-json-serialize-annotations.ttl
     └── spdx-model.ttl
 ```
 
-Useful for pre-release versions lacking official URLs and
-for testing new SPDX models.
+This is ideal for testing new models or pre-release versions where official
+URLs are not yet live.
 
 ## Usage
 


### PR DESCRIPTION
With PR https://github.com/spdx/spdx-python-model/pull/19 merged, we can now use `SHACL2CODE_SPDX_DIR` to load local model and context files.

Add document about it.