### PR TITLE
pyproject.toml: Update shacl2code to 1.1.0 and add keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,14 @@ authors = [
     {name = "Joshua Watt", email = "JPEWhacker@gmail.com"},
 ]
 readme = "README.md"
+keywords = [
+    "spdx",
+    "sbom",
+    "spdx3",
+    "software-bill-of-materials",
+    "shacl2code",
+    "bindings",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -36,7 +44,7 @@ Issues = "https://github.com/spdx/spdx-python-model/issues"
 requires = [
     "hatchling >= 1.27.0",
     "hatch-build-scripts >= 0.0.4",
-    "shacl2code == 1.0.1",
+    "shacl2code == 1.1.0",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
- Update shacl2code == 1.1.0
- Add keywords to help discover on PyPI. These keywords are added:
  - spdx
  - sbom
  - spdx3
  - software-bill-of-materials
  - shacl2code
  - bindings
