### PR TITLE
Add link to API doc in README and pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
-# SPDX Python model
+# spdx-python-model
 
 [![PyPI - Version](https://img.shields.io/pypi/v/spdx-python-model)](https://pypi.org/project/spdx-python-model/)
 ![Apache-2.0 license](https://img.shields.io/github/license/spdx/spdx-python-model)
 
-Generated Python code for [SPDX specification version 3][spdx-spec].
+`spdx-python-model` is a Python library for working with the SPDX 3 data model.
 
-All bindings in this repository are generated using
-[shacl2code](https://github.com/JPEWdev/shacl2code) at the time the package is
-built.
+Read the [API documentation](https://spdx.github.io/spdx-python-model/).
+
+All bindings in this repository are auto-generated from the RDF and SHACL
+definitions of the [SPDX specification version 3][spdx-spec] using
+[shacl2code](https://github.com/JPEWdev/shacl2code) during the package build
+process.
 
 **NOTE:** The bindings are pretty low level, intended for more directly
 manipulating SPDX files. While they are fully functions, they lack higher level
 helper functions that may be useful for creating SPDX documents. If you want a
 higher level approach, please see the
 [SPDX Python Tools](https://github.com/spdx/tools-python) (however, it
-doesn't yet support SPDX 3)
+doesn't yet support SPDX 3).
 
 [spdx-spec]: https://spdx.org/specifications
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "spdx_python_model"
+name = "spdx-python-model"
 description = "SPDX Model Python Bindings"
 dynamic = ["version"]
 dependencies = []
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 
 [project.optional-dependencies]
 dev = [
@@ -38,9 +39,11 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/spdx/spdx-python-model"
-Repository = "https://github.com/spdx/spdx-python-model.git"
-Issues = "https://github.com/spdx/spdx-python-model/issues"
+homepage = "https://spdx.github.io/spdx-python-model/"
+repository = "https://github.com/spdx/spdx-python-model.git"
+download = "https://github.com/spdx/spdx-python-model/releases"
+documentation = "https://spdx.github.io/spdx-python-model/doc/"
+issues = "https://github.com/spdx/spdx-python-model/issues"
 
 [build-system]
 requires = [

--- a/www/index.html
+++ b/www/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SPDX Python Model</title>
+  <title>spdx-python-model</title>
   <meta name="description"
     content="Python bindings for the SPDX 3 data model. Install instructions. API documentation.">
   <style>
@@ -44,7 +44,7 @@
 </head>
 
 <body>
-  <h1>SPDX Python Model</h1>
+  <h1>spdx-python-model</h1>
   <p class="tagline">Python bindings for the SPDX 3 data model.</p>
 
   <h2>Install</h2>


### PR DESCRIPTION
- Add API doc link to README
- Update pyproject.toml
  - Add more project.urls, including API doc
  - Use hyphen in project name (normalized project name, see [PEP 503](https://peps.python.org/pep-0503/#normalized-names)), adopt `spdx-python-model` name everywhere.