### PR TITLE
Fix doc publishing workflow name

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,7 +10,7 @@
 # Publish tutorials to
 # https://spdx.github.io/spdx-python-model/tutorial/
 
-name: Publish docs
+name: Publish API docs
 
 on:
   push:


### PR DESCRIPTION
The doc publication recently failed.

It is because GitHub Pages environment protection rules restricts the publication to the old name "Publish API docs".

Revert the name back.