### PR TITLE
Set "--include-main no" when generate bindings

### DIFF
--- a/gen/generate-bindings
+++ b/gen/generate-bindings
@@ -27,14 +27,16 @@ for v in $SPDX_VERSIONS; do
             --context-url "file://${SHACL2CODE_SPDX_DIR}/$v/spdx-context.jsonld" $CONTEXT_URL \
             --license Apache-2.0 \
             python \
-            --output "$MODNAME"
+            --output "$MODNAME" \
+            --include-main no
     else
         shacl2code generate --input https://spdx.org/rdf/$v/spdx-model.ttl \
             --input https://spdx.org/rdf/$v/spdx-json-serialize-annotations.ttl \
             --context $CONTEXT_URL \
             --license Apache-2.0 \
             python \
-            --output "$MODNAME"
+            --output "$MODNAME" \
+            --include-main no
     fi
 done
 


### PR DESCRIPTION
Currently command-line functions are included in the exported submodules.
Those functions may not be necessary for the bindings as a library.

This PR removes them.

(We can also keep them, no harm)